### PR TITLE
[Home page] The item descriptions are bold in the home page “How it works” block#63

### DIFF
--- a/src/components/title-with-description/TitleWithDescription.styles.js
+++ b/src/components/title-with-description/TitleWithDescription.styles.js
@@ -9,6 +9,7 @@ export const styles = {
     marginBottom: '16px'
   },
   description: {
+    fontWeight: 600,
     marginBottom: '0px'
   }
 }


### PR DESCRIPTION
- [x] The item descriptions in the home page “How it works” block are corresponded to the mockup.
![image](https://github.com/Space2Study-Project/Space2Study-FrontEnd/assets/102384883/ace73903-a816-4ce7-8ffd-ef9605e7dca7)
![image](https://github.com/Space2Study-Project/Space2Study-FrontEnd/assets/102384883/664181d7-eda6-48a0-b55e-1cc62803281b)
