### PR TITLE
change when press “Space2Study” logo buttom page scrooll to the top

### DIFF
--- a/src/components/scroll-to-top-button/ScrollToTopButton.jsx
+++ b/src/components/scroll-to-top-button/ScrollToTopButton.jsx
@@ -11,6 +11,7 @@ const ScrollToTopButton = ({ element }) => {
       behavior: 'smooth'
     })
   }
+  ScrollToTopButton.goToTop = goToTop
 
   return (
     <ScrollVisibilityWrapper heightToShow={450} pageRef={element}>

--- a/src/components/scroll-to-top-button/ScrollToTopButton.jsx
+++ b/src/components/scroll-to-top-button/ScrollToTopButton.jsx
@@ -3,20 +3,13 @@ import Box from '@mui/material/Box'
 import IconButton from '@mui/material/IconButton'
 import { styles } from '~/components/scroll-to-top-button/ScrollToTopButton.styles'
 import ScrollVisibilityWrapper from '~/components/scroll-visibility-wrapper/ScrollVisibilityWrapper'
+import { goToTop } from '~/services/scroll-to-top'
 
 const ScrollToTopButton = ({ element }) => {
-  const goToTop = () => {
-    element.current?.scrollTo({
-      top: 0,
-      behavior: 'smooth'
-    })
-  }
-  ScrollToTopButton.goToTop = goToTop
-
   return (
     <ScrollVisibilityWrapper heightToShow={450} pageRef={element}>
       <Box sx={styles.root}>
-        <IconButton onClick={goToTop} sx={styles.button}>
+        <IconButton onClick={() => goToTop(element)} sx={styles.button}>
           <ArrowUpwardRoundedIcon sx={styles.icon} />
         </IconButton>
       </Box>

--- a/src/containers/app-content/AppContent.jsx
+++ b/src/containers/app-content/AppContent.jsx
@@ -1,3 +1,4 @@
+import { useRef } from 'react'
 import Box from '@mui/material/Box'
 
 import { styles } from '~/containers/app-content/AppContent.styles'
@@ -5,10 +6,11 @@ import AppHeader from '~/containers/layout/app-header/AppHeader'
 import AppMain from '~/containers/layout/app-main/AppMain'
 
 const AppContent = () => {
+  const mainWithFooter = useRef(null)
   return (
     <Box data-testid='AppContent' sx={styles.root}>
-      <AppHeader />
-      <AppMain />
+      <AppHeader mainWithFooter={mainWithFooter} />
+      <AppMain mainWithFooter={mainWithFooter} />
     </Box>
   )
 }

--- a/src/containers/layout/app-header/AppHeader.jsx
+++ b/src/containers/layout/app-header/AppHeader.jsx
@@ -3,11 +3,11 @@ import Toolbar from '@mui/material/Toolbar'
 import NavBar from '~/containers/layout/navbar/NavBar'
 import { styles } from '~/containers/layout/app-header/AppHeader.styles'
 
-const AppHeader = () => {
+const AppHeader = ({ mainWithFooter }) => {
   return (
     <>
       <AppBar sx={styles.appBar}>
-        <NavBar />
+        <NavBar mainWithFooter={mainWithFooter} />
       </AppBar>
       <Toolbar data-testid='toolbar' sx={styles.toolBar} />
     </>

--- a/src/containers/layout/app-main/AppMain.jsx
+++ b/src/containers/layout/app-main/AppMain.jsx
@@ -1,5 +1,5 @@
 import Box from '@mui/material/Box'
-import { Suspense, useLayoutEffect, useRef } from 'react'
+import { Suspense, useLayoutEffect } from 'react'
 import { useDispatch, useSelector } from 'react-redux'
 import { Outlet, useNavigation } from 'react-router-dom'
 
@@ -11,8 +11,7 @@ import AppBreadCrumbs from '~/containers/layout/app-breadcrumbs/AppBreadCrumbs'
 import Footer from '~/containers/layout/footer/Footer'
 import { checkAuth } from '~/redux/reducer'
 
-const AppMain = () => {
-  const mainWithFooter = useRef(null)
+const AppMain = ({ mainWithFooter }) => {
   const { loading } = useSelector((state) => state.appMain)
   const { state } = useNavigation()
   const dispatch = useDispatch()

--- a/src/containers/layout/navbar/NavBar.jsx
+++ b/src/containers/layout/navbar/NavBar.jsx
@@ -1,5 +1,4 @@
-import ScrollToTopButton from '~/components/scroll-to-top-button/ScrollToTopButton'
-import { Fragment, useMemo, useRef } from 'react'
+import { Fragment, useMemo } from 'react'
 import { useTranslation } from 'react-i18next'
 import { matchPath, useLocation, Link } from 'react-router-dom'
 
@@ -23,9 +22,9 @@ import { tutorRoutes } from '~/router/constants/tutorRoutes'
 import { useSelector } from 'react-redux'
 import { student, tutor } from '~/constants'
 import { styles } from '~/containers/layout/navbar/NavBar.styles'
+import { goToTop } from '~/services/scroll-to-top'
 
-const Navbar = () => {
-  const mainWithFooter = useRef(null)
+const Navbar = ({ mainWithFooter }) => {
   const { userRole } = useSelector((state) => state.appMain)
   const { openDrawer, closeDrawer, isOpen } = useDrawer()
   const { pathname } = useLocation()
@@ -50,7 +49,8 @@ const Navbar = () => {
   }, [userRole])
 
   const handleLogoClick = () => {
-    ScrollToTopButton.goToTop(mainWithFooter)
+    console.log(mainWithFooter)
+    goToTop(mainWithFooter)
   }
 
   const handleOpenSidebar = () => {
@@ -78,8 +78,7 @@ const Navbar = () => {
   })
 
   return (
-    <Box ref={mainWithFooter} sx={styles.header}>
-      <ScrollToTopButton element={mainWithFooter} />
+    <Box sx={styles.header}>
       <Button
         component={Link}
         onClick={handleLogoClick}

--- a/src/containers/layout/navbar/NavBar.jsx
+++ b/src/containers/layout/navbar/NavBar.jsx
@@ -1,4 +1,5 @@
-import { Fragment, useMemo } from 'react'
+import ScrollToTopButton from '~/components/scroll-to-top-button/ScrollToTopButton'
+import { Fragment, useMemo, useRef } from 'react'
 import { useTranslation } from 'react-i18next'
 import { matchPath, useLocation, Link } from 'react-router-dom'
 
@@ -24,12 +25,15 @@ import { student, tutor } from '~/constants'
 import { styles } from '~/containers/layout/navbar/NavBar.styles'
 
 const Navbar = () => {
+  const mainWithFooter = useRef(null)
   const { userRole } = useSelector((state) => state.appMain)
   const { openDrawer, closeDrawer, isOpen } = useDrawer()
   const { pathname } = useLocation()
   const { t } = useTranslation()
 
-  const homePath = userRole ? guestRoutes[userRole].path : guestRoutes.home.path
+  const homePath = userRole
+    ? guestRoutes[userRole].path
+    : guestRoutes.welcome.path
 
   const navigationItems = useMemo(() => {
     if (userRole === student) {
@@ -44,6 +48,10 @@ const Navbar = () => {
     if (!userRole) return []
     return Object.values(authRoutes.accountMenu)
   }, [userRole])
+
+  const handleLogoClick = () => {
+    ScrollToTopButton.goToTop(mainWithFooter)
+  }
 
   const handleOpenSidebar = () => {
     openDrawer()
@@ -70,9 +78,11 @@ const Navbar = () => {
   })
 
   return (
-    <Box sx={styles.header}>
+    <Box ref={mainWithFooter} sx={styles.header}>
+      <ScrollToTopButton element={mainWithFooter} />
       <Button
         component={Link}
+        onClick={handleLogoClick}
         size={'small'}
         sx={styles.logoButton}
         to={homePath}

--- a/src/containers/layout/navbar/NavBar.jsx
+++ b/src/containers/layout/navbar/NavBar.jsx
@@ -30,9 +30,7 @@ const Navbar = ({ mainWithFooter }) => {
   const { pathname } = useLocation()
   const { t } = useTranslation()
 
-  const homePath = userRole
-    ? guestRoutes[userRole].path
-    : guestRoutes.welcome.path
+  const homePath = userRole ? guestRoutes[userRole].path : guestRoutes.home.path
 
   const navigationItems = useMemo(() => {
     if (userRole === student) {

--- a/src/containers/layout/navbar/NavBar.jsx
+++ b/src/containers/layout/navbar/NavBar.jsx
@@ -49,7 +49,6 @@ const Navbar = ({ mainWithFooter }) => {
   }, [userRole])
 
   const handleLogoClick = () => {
-    console.log(mainWithFooter)
     goToTop(mainWithFooter)
   }
 

--- a/src/services/scroll-to-top.js
+++ b/src/services/scroll-to-top.js
@@ -1,0 +1,6 @@
+export const goToTop = (element) => {
+  element.current?.scrollTo({
+    top: 0,
+    behavior: 'smooth'
+  })
+}

--- a/src/services/scroll-to-top.js
+++ b/src/services/scroll-to-top.js
@@ -1,5 +1,5 @@
 export const goToTop = (element) => {
-  element.current?.scrollTo({
+  element?.current?.scrollTo({
     top: 0,
     behavior: 'smooth'
   })

--- a/tests/unit/components/layout/AppMain.spec.jsx
+++ b/tests/unit/components/layout/AppMain.spec.jsx
@@ -31,13 +31,15 @@ vi.mock('react-redux', async () => {
 
 describe('AppMain layout component test', () => {
   it('should render loader', () => {
-    renderWithProviders(<AppMain />, { preloadedState: mockState })
+    renderWithProviders(<AppMain mainWithFooter={{}} />, {
+      preloadedState: mockState
+    })
     const loader = screen.getByTestId('loader')
     expect(loader).toBeInTheDocument()
   })
 
   it('should dispatch checkAuth if accessToken exists in localStorage', async () => {
-    renderWithProviders(<AppMain />, {
+    renderWithProviders(<AppMain mainWithFooter={{}} />, {
       preloadedState: {
         appMain: {
           authLoading: false,


### PR DESCRIPTION
Close #65 
The system scrolls back to the home page welcoming block after clicking on the “Space2Study” logo button on the header.
Return to the previous commit, make new branch from my previous

https://github.com/Space2Study-Project/Space2Study-FrontEnd/assets/122298176/a17d47c8-ec0d-4786-b69a-47b18d1bfa96

