### PR TITLE
fix regexp

### DIFF
--- a/src/utils/validations/common.js
+++ b/src/utils/validations/common.js
@@ -1,6 +1,6 @@
 const validations = {
   nameField: (value) => {
-    if (value.length > 30) {
+    if (value.length < 2 || value.length > 16) {
       return 'common.errorMessages.nameLength'
     }
     if (!RegExp(/^[a-zа-яєії ]+$/i).test(value)) {


### PR DESCRIPTION
close #152 
- [x] "First Name" and "Last Name" fields must receive a string in a range from 2 to 15 symbols.
- [x] The email field must be for emails.
- [x] Password must contain at least one alphabetic and one numeric character.
- [x] The "Confirm Password" field must be connected with the "Password" field.