### PR TITLE
Add Language step#177 (LanguageStep component, tests, styles added)

### DIFF
--- a/src/containers/tutor-home-page/language-step/LanguageStep.jsx
+++ b/src/containers/tutor-home-page/language-step/LanguageStep.jsx
@@ -1,12 +1,51 @@
-import Box from '@mui/material/Box'
+import { Box, Autocomplete, TextField, Typography } from '@mui/material'
+import { useTranslation } from 'react-i18next'
+import { useState } from 'react'
 
 import { styles } from '~/containers/tutor-home-page/language-step/LanguageStep.styles'
+import languageImg from '~/assets/img/tutor-home-page/become-tutor/languages.svg'
+
+import { languages } from './constants'
 
 const LanguageStep = ({ btnsBox }) => {
+  const { t } = useTranslation()
+  const [selectedLanguage, setSelectedLanguage] = useState(null)
+
+  const handleLanguageChange = (event, newValue) => {
+    setSelectedLanguage(newValue)
+  }
+
   return (
     <Box sx={styles.container}>
-      Language step
-      {btnsBox}
+      <Box sx={styles.imgContainer}>
+        <Box
+          alt='language img'
+          component='img'
+          src={languageImg}
+          sx={styles.img}
+        />
+      </Box>
+      <Box>
+        <Box data-testid='inputContainer' sx={styles.inputContainer}>
+          <Typography sx={styles.title}>
+            {t('becomeTutor.languages.title')}
+          </Typography>
+          <Autocomplete
+            onChange={handleLanguageChange}
+            options={languages}
+            renderInput={(params) => (
+              <TextField
+                {...params}
+                label={t('becomeTutor.languages.autocompleteLabel')}
+              />
+            )}
+            sx={styles.inputItem}
+            value={selectedLanguage}
+          />
+        </Box>
+
+        <Box sx={styles.btnsBox}>{btnsBox}</Box>
+      </Box>
     </Box>
   )
 }

--- a/src/containers/tutor-home-page/language-step/LanguageStep.styles.js
+++ b/src/containers/tutor-home-page/language-step/LanguageStep.styles.js
@@ -1,17 +1,19 @@
 import { fadeAnimation } from '~/styles/app-theme/custom-animations'
-
+const containerCommon = {
+  display: 'flex',
+  justifyContent: 'space-between',
+  height: { sm: '485px' },
+  paddingBottom: { xs: '30px', sm: '0px' },
+  flexDirection: { xs: 'column', md: 'row' },
+  ...fadeAnimation
+}
 export const styles = {
   container: {
-    display: 'flex',
-    justifyContent: 'space-between',
-    gap: { md: '25px', lg: '80px' },
-    height: { sm: '485px' },
-    paddingBottom: { xs: '30px', sm: '0px' },
-    flexDirection: { xs: 'column', md: 'row' },
-    ...fadeAnimation
+    ...containerCommon,
+    gap: { md: '25px', lg: '80px' }
   },
   imgContainer: {
-    display: 'flex',
+    ...containerCommon,
     alignItems: 'flex-start',
     width: { sm: '100%', md: '38%', lg: '50%' },
     maxWidth: { md: '370px', lg: '472px' },
@@ -23,7 +25,7 @@ export const styles = {
     marginBottom: '30px'
   },
   inputContainer: {
-    display: 'flex',
+    ...containerCommon,
     flexDirection: 'column',
     width: { sm: '100%', md: '100%', lg: '100%' },
     maxWidth: { md: '430px', lg: '455px' }
@@ -36,7 +38,7 @@ export const styles = {
     height: '65%'
   },
   inputItem: {
-    display: 'flex',
+    ...containerCommon,
     justifyContent: 'space-between',
     marginBottom: '30px'
   },

--- a/src/containers/tutor-home-page/language-step/LanguageStep.styles.js
+++ b/src/containers/tutor-home-page/language-step/LanguageStep.styles.js
@@ -4,8 +4,43 @@ export const styles = {
   container: {
     display: 'flex',
     justifyContent: 'space-between',
-    gap: '40px',
+    gap: { md: '25px', lg: '80px' },
     height: { sm: '485px' },
+    paddingBottom: { xs: '30px', sm: '0px' },
+    flexDirection: { xs: 'column', md: 'row' },
     ...fadeAnimation
+  },
+  imgContainer: {
+    display: 'flex',
+    alignItems: 'flex-start',
+    width: { sm: '100%', md: '38%', lg: '50%' },
+    maxWidth: { md: '370px', lg: '472px' },
+    maxHeight: 'inherit'
+  },
+  img: {
+    objectFit: 'contain',
+    width: '100%',
+    marginBottom: '30px'
+  },
+  inputContainer: {
+    display: 'flex',
+    flexDirection: 'column',
+    width: { sm: '100%', md: '100%', lg: '100%' },
+    maxWidth: { md: '430px', lg: '455px' }
+  },
+  btnsBox: {
+    marginTop: 'auto',
+    display: 'flex',
+    flexDirection: 'column-reverse',
+    marginBottom: 'auto',
+    height: '65%'
+  },
+  inputItem: {
+    display: 'flex',
+    justifyContent: 'space-between',
+    marginBottom: '30px'
+  },
+  title: {
+    marginBottom: '30px'
   }
 }

--- a/src/redux/reducer.js
+++ b/src/redux/reducer.js
@@ -114,15 +114,15 @@ export const mainSlice = createSlice({
       const userData = parseJwt(action.payload)
       state.userId = userData.id
       state.userRole = userData.role
-      state.isFirstLogin = true
+      state.isFirstLogin = userData.isFirstLogin
     },
     logout(state) {
       state.userId = initialState.userId
       state.userRole = initialState.userRole
-      state.isFirstLogin = true
+      state.isFirstLogin = initialState.isFirstLogin
     },
     markFirstLoginComplete(state) {
-      state.isFirstLogin = true
+      state.isFirstLogin = false
     },
     setPageLoading(state, action) {
       state.pageLoad = action.payload

--- a/src/redux/reducer.js
+++ b/src/redux/reducer.js
@@ -114,15 +114,15 @@ export const mainSlice = createSlice({
       const userData = parseJwt(action.payload)
       state.userId = userData.id
       state.userRole = userData.role
-      state.isFirstLogin = userData.isFirstLogin
+      state.isFirstLogin = true
     },
     logout(state) {
       state.userId = initialState.userId
       state.userRole = initialState.userRole
-      state.isFirstLogin = initialState.isFirstLogin
+      state.isFirstLogin = true
     },
     markFirstLoginComplete(state) {
-      state.isFirstLogin = false
+      state.isFirstLogin = true
     },
     setPageLoading(state, action) {
       state.pageLoad = action.payload

--- a/tests/unit/containers/tutor-home-page/language-step/LanguageStep.spec.jsx
+++ b/tests/unit/containers/tutor-home-page/language-step/LanguageStep.spec.jsx
@@ -65,8 +65,8 @@ describe('LanguageStep Container', () => {
     )
 
     waitFor(() => {
-      const categoryName = screen.getByText('English')
-      expect(categoryName).toBeInTheDocument()
+      const languageName = screen.getByText('English')
+      expect(languageName).toBeInTheDocument()
     })
   })
 })

--- a/tests/unit/containers/tutor-home-page/language-step/LanguageStep.spec.jsx
+++ b/tests/unit/containers/tutor-home-page/language-step/LanguageStep.spec.jsx
@@ -1,14 +1,37 @@
-import { render, screen } from '@testing-library/react'
+import { render, fireEvent, screen, waitFor } from '@testing-library/react'
+import { beforeEach, vi } from 'vitest'
+
 import LanguageStep from '~/containers/tutor-home-page/language-step/LanguageStep'
 
+vi.mock('react-i18next', () => ({
+  useTranslation: () => {
+    return {
+      t: (str) => str
+    }
+  }
+}))
+
 describe('LanguageStep Container', () => {
+  beforeEach(() => {
+    render(<LanguageStep btnsBox={<div data-testid='mockedBtnsBox' />} />)
+  })
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('displays the language category image', () => {
+    const languageImage = screen.getByAltText('language img')
+
+    expect(languageImage).toBeInTheDocument()
+    expect(languageImage).toHaveAttribute(
+      'src',
+      expect.stringContaining('languages.svg')
+    )
+  })
+
   it('should render the container', () => {
-    const mockBtnsBox = <div data-testid='mock-btns-box'>Mock Buttons Box</div>
-    render(<LanguageStep btnsBox={mockBtnsBox} />)
-    const containerElement = screen.getByText('Language step')
+    const containerElement = screen.getByText(/becomeTutor.languages.title/i)
     expect(containerElement).toBeInTheDocument()
-    const btnsBoxElement = screen.getByTestId('mock-btns-box')
-    expect(btnsBoxElement).toBeInTheDocument()
   })
 
   it('should check if the buttons passed in props are in the document', () => {
@@ -23,5 +46,27 @@ describe('LanguageStep Container', () => {
     expect(button1Element).toBeInTheDocument()
     const button2Element = screen.getByTestId('button-2')
     expect(button2Element).toBeInTheDocument()
+  })
+
+  it('should render input box', () => {
+    const inputContainer = screen.getByTestId('inputContainer')
+    expect(inputContainer).toBeInTheDocument()
+  })
+
+  it('should render Autocomplete input', () => {
+    expect(
+      screen.getByLabelText(/becomeTutor.languages.autocompleteLabel/i)
+    ).toBeInTheDocument()
+  })
+
+  it('handles language change', () => {
+    fireEvent.click(
+      screen.getByLabelText(/becomeTutor.languages.autocompleteLabel/i)
+    )
+
+    waitFor(() => {
+      const categoryName = screen.getByText('English')
+      expect(categoryName).toBeInTheDocument()
+    })
   })
 })


### PR DESCRIPTION
close #177 

- [x] Photo and select field in the language info step for both student and tutor steppers
- [x] When user clicks on select it should fetch existing languages from server
- [x] When user clicks on criss-cross it should remove select field value(We reviewed the code and found that currently the list of languages is not being fetched from the backend but rather from a constants.js file.)

students stepper
![Zrzut ekranu 2023-12-12 o 13 19 34](https://github.com/Space2Study-Project/Space2Study-FrontEnd/assets/123500008/b15d23ac-139e-451c-b3ff-f0a74593ea48)


tutor stepper
<img width="1076" alt="Zrzut ekranu 2023-12-12 o 13 20 13" src="https://github.com/Space2Study-Project/Space2Study-FrontEnd/assets/123500008/e627e3ac-c264-476a-87e7-8b5ffd9ccdd7">
<img width="1074" alt="Zrzut ekranu 2023-12-12 o 13 20 19" src="https://github.com/Space2Study-Project/Space2Study-FrontEnd/assets/123500008/f190ee36-6f05-4218-91b5-d1656e565a4a">
<img width="1059" alt="Zrzut ekranu 2023-12-12 o 13 20 30" src="https://github.com/Space2Study-Project/Space2Study-FrontEnd/assets/123500008/89be54c9-0dea-46d9-a487-c78ca19601b0">
![Zrzut ekranu 2023-12-12 o 13 22 19](https://github.com/Space2Study-Project/Space2Study-FrontEnd/assets/123500008/7213c580-8ef0-47dd-a594-c09e5cba7211)


